### PR TITLE
Ui refinements

### DIFF
--- a/fec/fec/static/hbs/calendar/details.hbs
+++ b/fec/fec/static/hbs/calendar/details.hbs
@@ -1,18 +1,21 @@
-<div class="tooltip tooltip--under calendar__details">
+<div class="tooltip tooltip--under cal-details">
   <button class="button button--close--primary js-close" type="button"><span class="u-visually-hidden">Close</span></button>
-  <span class="t-block t-bold">
+  <span class="cal-details__date">
     {{#if allDay}}
-      {{datetime start}}
+      {{datetime start format="pretty"}}
     {{else}}
       {{datetime start format="dateTime"}}&ndash;{{datetime end format="dateTime"}}
     {{/if}}
   </span>
-  <span class="t-block t-bold">{{ title }}</span>
-  <span class="t-block">{{ summary }}</span>
-  {{#if location }}
-    <span class="t-block"><span class="t-bold">Location: </span>{{ location }}</span>
+  <span class="cal-details__title">{{ title }}</span>
+  <span class="cal-details__summary">{{ summary }}</span>
+  {{#if state }}
+  <span class="cal-details__summary"><span class="t-bold">States:</span> {{ state }}</span>
   {{/if}}
-  <div class="dropdown">
+  {{#if location }}
+    <span class="cal-details__location"><span class="t-bold">Location: </span>{{ location }}</span>
+  {{/if}}
+  <div class="cal-details__add dropdown">
     <button class="button button--neutral dropdown__button button--calendar">Add to calendar</button>
     <ul class="dropdown__panel" aria-hidden="true">
       <li class="dropdown__item"><a class="dropdown__value" href="{{download}}">Apple Calendar</a></li>

--- a/fec/fec/static/hbs/calendar/events.hbs
+++ b/fec/fec/static/hbs/calendar/events.hbs
@@ -1,11 +1,11 @@
 {{#each groups}}
-  <hr />
-  <h4>{{title}}</h4>
+<div class="cal-list__group">
+  <h3 class="cal-list__title">{{title}}</h3>
   {{#each events}}
-    <div class="row">
-      <div class="usa-width-one-twelfth">
+    <div class="cal-list__event">
+      <div class="cal-list__add">
         <div class="dropdown">
-          <button class="button button--neutral dropdown__button button--calendar">&nbsp;</button>
+          <button class="button button--neutral dropdown__button dropdown__button--mini button--calendar--mini"><span class="u-visually-hidden">Download calendar</span></button>
           <ul class="dropdown__panel" aria-hidden="true">
             <li class="dropdown__item"><a class="dropdown__value" href="{{download}}">Apple Calendar</a></li>
             <li class="dropdown__item"><a class="dropdown__value" href="{{google}}" target="_blank">Google Calendar</a></li>
@@ -13,21 +13,23 @@
           </ul>
         </div>
       </div>
-      <div class="usa-width-one-twelfth">{{datetime start format="pretty"}}</div>
-      <div class="usa-width-one-twelfth">
+      <div class="cal-list__date">
+        <span class="t-block">{{datetime start format="pretty"}}</span>
+        <span class="t-block">{{datetime start format="dayOfWeek"}}</span>
+      </div>
+      <div class="cal-list__time">
         {{#if end}}
           {{datetime start format="time"}}&ndash;{{datetime end format="time"}}
         {{else}}
           All day
         {{/if}}
       </div>
-      <div class="usa-width-one-half">
-        <div class="ev-list">
-          <h5>{{title}}</h5>
-          <p>{{summary}}</p>
-        </div>
+      <div class="cal-list__description">
+        <h5 class="cal-list__event-title">{{title}}</h5>
+        <p>{{summary}}</p>
       </div>
-      <div class="usa-width-one-fourth">{{location}}</div>
+      <div class="cal-list__location">{{location}}</div>
     </div>
   {{/each}}
+</div>
 {{/each}}

--- a/fec/fec/static/js/calendar.js
+++ b/fec/fec/static/js/calendar.js
@@ -149,6 +149,11 @@ Calendar.prototype.defaultOpts = function() {
       eventLimit: true,
       nowIndicator: true,
       views: {
+        agenda: {
+          scrollTime: '09:00:00',
+          minTime: '08:00:00',
+          maxTime: '20:00:00',
+        },
         month: {
           eventLimit: 3,
           buttonText: 'Month'


### PR DESCRIPTION
- Adds necessary markup to the calendar components for the latest styles
- Adds state to detail tooltips
- Adds DayRender callback to add the month name to the first of the month
- Adds ViewRender callback to highlight the full “today” cells
- Correctly applies the “fc—allday” class to only full day events
- Sets limit on weekview

![screen shot 2016-01-25 at 6 48 08 pm](https://cloud.githubusercontent.com/assets/1696495/12573046/edb0c4c6-c3a8-11e5-8f80-3270846b02f6.png)

^ :eyes: @jenniferthibault
