### PR TITLE
Updating election filter + adding url

### DIFF
--- a/fec/fec/constants.py
+++ b/fec/fec/constants.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 
 election_types = OrderedDict([
-    ('election', 'Elections'),
+    ('election', 'All elections'),
 ])
 
 deadline_types = OrderedDict([

--- a/fec/fec/static/hbs/calendar/details.hbs
+++ b/fec/fec/static/hbs/calendar/details.hbs
@@ -11,6 +11,9 @@
   {{#if location }}
     <span class="cal-details__location"><span class="t-bold">Location: </span>{{ location }}</span>
   {{/if}}
+  {{#if url }}
+    <span class="t-block"><a class="t-bold" href="{{ url }}">Learn more</a></span>
+  {{/if}}
   <div class="cal-details__add dropdown">
     <button class="button button--neutral dropdown__button button--calendar">Add to calendar</button>
     <ul class="dropdown__panel" aria-hidden="true">

--- a/fec/fec/static/hbs/calendar/events.hbs
+++ b/fec/fec/static/hbs/calendar/events.hbs
@@ -22,6 +22,9 @@
           {{#if location}}
             <span class="cal-list__location">&ndash; {{location}}</span>
           {{/if}}
+          {{#if url }}
+            <span class="t-block"><a class="t-bold" href="{{ url }}">Learn more</a></span>
+          {{/if}}
         </div>
       </div>
       <div class="cal-list__add">

--- a/fec/fec/static/js/calendar.js
+++ b/fec/fec/static/js/calendar.js
@@ -249,7 +249,8 @@ Calendar.prototype.success = function(response) {
       start: event.start_date ? moment.utc(event.start_date) : null,
       end: event.end_date ? moment.utc(event.end_date) : null,
       allDay: moment.utc(event.start_date).format('HHmmss') === '000000' && event.end_date === null,
-      className: getEventClass(event)
+      className: getEventClass(event),
+      url: event.url || null
     };
     _.extend(processed, {
       google: getGoogleUrl(processed),


### PR DESCRIPTION
This adds resource URLs to events and updates language on the election filter.

However! There seems to be something weird going on with event bubbling where clicking on any calendar event that has a url in the tooltip automatically opens the page for that URL. I tried `.stopPropagation()` but it didn't help. Do you mind taking a look?

Resolves https://github.com/18F/openFEC/issues/1455
